### PR TITLE
Avoid unused typedef warnings with clang

### DIFF
--- a/include/boost/static_assert.hpp
+++ b/include/boost/static_assert.hpp
@@ -67,7 +67,7 @@
 //
 // If the compiler warns about unused typedefs then enable this:
 //
-#if defined(__GNUC__) && ((__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 7)))
+#if defined(__GNUC__) && (__GNUC__ >= 4)
 #  define BOOST_STATIC_ASSERT_UNUSED_ATTRIBUTE __attribute__((unused))
 #else
 #  define BOOST_STATIC_ASSERT_UNUSED_ATTRIBUTE


### PR DESCRIPTION
Clang generates warnings about unused typedefs when using BOOST_STATIC_ASSERT.
The workaround for this already exists, but for some reason is restricted to GCC 4.7+.
Since the 'unused' attribute has existed since the GCC 3.x days, we might as well enable it for any GCC 4.x, which also includes Clang, which is compatible with GCC 4.2.
