### PR TITLE
Simplified boolean expression

### DIFF
--- a/include/boost/static_assert.hpp
+++ b/include/boost/static_assert.hpp
@@ -53,9 +53,9 @@
 //
 #if defined(__GNUC__) && ((__GNUC__ > 3) || ((__GNUC__ == 3) && (__GNUC_MINOR__ >= 4)))
 #  ifndef BOOST_NO_CXX11_VARIADIC_MACROS
-#     define BOOST_STATIC_ASSERT_BOOL_CAST( ... ) ((__VA_ARGS__) == 0 ? false : true)
+#     define BOOST_STATIC_ASSERT_BOOL_CAST( ... ) ((__VA_ARGS__) != 0)
 #  else
-#     define BOOST_STATIC_ASSERT_BOOL_CAST( x ) ((x) == 0 ? false : true)
+#     define BOOST_STATIC_ASSERT_BOOL_CAST( x ) ((x) != 0)
 #  endif
 #else
 #  ifndef BOOST_NO_CXX11_VARIADIC_MACROS


### PR DESCRIPTION
This is a fix for clang-tidy readability-simplify-boolean-expr. Because this is a macro clang is picking this up even with Boost as system header.